### PR TITLE
build: config directus-db chemin volume

### DIFF
--- a/env/local/docker/directus/docker-compose.yml
+++ b/env/local/docker/directus/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "5432:5432"
     # Uncomment to persist data on your local storage
     # volumes:
-    #   - '/postgres-data:/var/lib/postgresql/data'
+    #   - './postgres-data:/var/lib/postgresql/data'
     networks:
       - directus
     environment:


### PR DESCRIPTION
Le chemin du volume de `directus-db` proposé dans le docker compose n'est pas un chemin relatif, donc ça risque de ne pas fonctionner sur certains systèmes.