### PR TITLE
feat(@multi-backend/map): chargement du fichier `.env`

### DIFF
--- a/dev/user-backend-nest/microservices/map/package-lock.json
+++ b/dev/user-backend-nest/microservices/map/package-lock.json
@@ -10,6 +10,7 @@
       "license": "CECILL-2.1",
       "dependencies": {
         "@nestjs/common": "^10.2.4",
+        "@nestjs/config": "^3.0.1",
         "@nestjs/core": "^10.2.4",
         "@nestjs/microservices": "^10.2.4",
         "@nestjs/platform-express": "^10.2.4",
@@ -2288,6 +2289,22 @@
         }
       }
     },
+    "node_modules/@nestjs/config": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-3.2.2.tgz",
+      "integrity": "sha512-vGICPOui5vE6kPz1iwQ7oCnp3qWgqxldPmBQ9onkVoKlBtyc83KJCr7CjuVtf4OdovMAVcux1d8Q6jglU2ZphA==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "16.4.5",
+        "dotenv-expand": "10.0.0",
+        "lodash": "4.17.21",
+        "uuid": "9.0.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
     "node_modules/@nestjs/core": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.2.4.tgz",
@@ -4236,6 +4253,27 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ee-first": {
@@ -7580,8 +7618,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -9681,6 +9718,19 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -11739,6 +11789,17 @@
         "uid": "2.0.2"
       }
     },
+    "@nestjs/config": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-3.2.2.tgz",
+      "integrity": "sha512-vGICPOui5vE6kPz1iwQ7oCnp3qWgqxldPmBQ9onkVoKlBtyc83KJCr7CjuVtf4OdovMAVcux1d8Q6jglU2ZphA==",
+      "requires": {
+        "dotenv": "16.4.5",
+        "dotenv-expand": "10.0.0",
+        "lodash": "4.17.21",
+        "uuid": "9.0.1"
+      }
+    },
     "@nestjs/core": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.2.4.tgz",
@@ -13193,6 +13254,16 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="
+    },
+    "dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A=="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -15784,8 +15855,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -17294,6 +17364,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
+    },
+    "uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/dev/user-backend-nest/microservices/map/package.json
+++ b/dev/user-backend-nest/microservices/map/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@nestjs/common": "^10.2.4",
+    "@nestjs/config": "^3.0.1",
     "@nestjs/core": "^10.2.4",
     "@nestjs/microservices": "^10.2.4",
     "@nestjs/platform-express": "^10.2.4",

--- a/dev/user-backend-nest/microservices/map/src/app.module.ts
+++ b/dev/user-backend-nest/microservices/map/src/app.module.ts
@@ -38,10 +38,11 @@
  */
 
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { MapModule } from './map/map.module';
 import { MonitoringModule } from './monitoring/monitoring.module';
 @Module({
-  imports: [MapModule, MonitoringModule],
+  imports: [ConfigModule.forRoot(), MapModule, MonitoringModule],
   controllers: [],
   providers: [],
 })


### PR DESCRIPTION
Bonjour,

Voici un petit pull request pour corriger le chargement du fichier `.env` au niveau du microservice `map`.

Puisque le module de configuration de NestJS n'est pas appelé, dotenv n'est pas invoqué non plus ce qui fait que `process.env` ne contient pas les valeurs du fichier.

Pour reproduire le souci, il suffit de changer la valeur du serveur NATS et constater que le `npm run start` tente de contacter `nats://localhost:4222` quelque soit la valeur dans le fichier.

Bon après-midi.