### PR TITLE
feat(@multi-frontend/important-news): visualisation alternative pour le widget

### DIFF
--- a/dev/user-frontend-ionic/projects/important-news/README.md
+++ b/dev/user-frontend-ionic/projects/important-news/README.md
@@ -4,3 +4,15 @@ Module permettant l'affichage d'un widget d'informations importantes.
 
 ## Widgets
 - `important-news` : Widget qui affiche les informations importantes.
+
+## Configuration
+Exemple dans `environment.ts` :
+
+```typescript
+ImportantNewsModule.forRoot({ 
+  display: 'vertically'
+})
+```
+
+### Configuration du widget
+- `display` : ("horizontally" | "vertically") : choix de la division, horizontale ou verticale

--- a/dev/user-frontend-ionic/projects/important-news/src/lib/important-news.config.ts
+++ b/dev/user-frontend-ionic/projects/important-news/src/lib/important-news.config.ts
@@ -40,7 +40,7 @@
 import { InjectionToken } from '@angular/core';
 
 export interface ImportantNewsModuleConfig {
-  display: "vertically" | "horizontally";
+  display: 'vertically' | 'horizontally';
 }
 
 export const IMPORTANT_NEWS_CONFIG =

--- a/dev/user-frontend-ionic/projects/important-news/src/lib/important-news.config.ts
+++ b/dev/user-frontend-ionic/projects/important-news/src/lib/important-news.config.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright ou © ou Copr. Université de Lorraine, (2022)
  *
  * Direction du Numérique de l'Université de Lorraine - SIED
@@ -37,114 +37,11 @@
  * termes.
  */
 
-.importantNews {
-  --border-bottom: 0.3rem;
+import { InjectionToken } from '@angular/core';
+
+export interface ImportantNewsModuleConfig {
+  display: "vertically" | "horizontally";
 }
 
-.text-title {
-  margin-top: 2rem;
-  margin-left: 0.625rem;
-  margin-right: 0.7rem;
-}
-
-.text-content {
-  margin-top: 0.875rem;
-  margin-left: 0.625rem;
-  margin-right: 0.7rem;
-  margin-bottom: 2rem;
-}
-
-.link-icon {
-  margin-left: 0.3rem;
-}
-
-.link-button {
-  margin-top: 0.3rem;
-  margin-right: -0.4rem;
-  margin-bottom: 0px;
-}
-
-ion-img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.news-content {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-}
-
-.news-content.without-image {
-  padding-left: 1em;
-
-  @supports (padding-left: env(safe-area-inset-left)) {
-    padding-left: calc(1em + env(safe-area-inset-left));
-  }
-
-  @supports (padding-right: env(safe-area-inset-right)) {
-    padding-right: env(safe-area-inset-right);
-  }
-
-  .text-content {
-    margin-left: 0rem;
-  }
-
-  .text-title {
-    margin-left: 0rem;
-  }
-}
-
-/*.border-bottom {
-  border-bottom: var(--app-border-width-5) solid var(--ion-color-secondary) !important;
-}*/
-
-.border {
-  //border-top: var(--app-border-width-7) solid var(--app-border-color-primary) !important;
-  //border-bottom: var(--app-border-width-7) solid var(--app-border-color-primary) !important;
-}
-
-.light-font-color{
-  color: var(--app-font-color-for-dark-background-from-cms) !important;
-}
-
-.dark-font-color{
-  color: var(--app-font-color-for-light-background-from-cms) !important;
-}
-
-
-.important-news-horizontally-style {
-
-  .img-container {
-    height: 170px;
-  }
-
-  .text-title {
-    margin-top: 1rem;
-    margin-left: 0.7rem;
-    margin-bottom: 0.5rem;
-  }
-
-  .text-content {
-    margin-top: 0;
-    margin-left: 0.7rem;
-    margin-right: 0.7rem;
-    margin-bottom: 0.5rem;
-  }
-
-  .link-button {
-    min-height: auto;
-    margin: 0 0 0.5rem;
-    --padding-end: 0.7rem;
-  }
-
-  .news-content {
-    border-left: var(--app-border-width-5) solid var(--ion-color-secondary) !important;
-  }
-
-  .news-content > ion-label:last-child {
-    margin-bottom: 1rem;
-  }
-
-}
+export const IMPORTANT_NEWS_CONFIG =
+  new InjectionToken<ImportantNewsModuleConfig>('Important news module config');

--- a/dev/user-frontend-ionic/projects/important-news/src/lib/important-news.module.ts
+++ b/dev/user-frontend-ionic/projects/important-news/src/lib/important-news.module.ts
@@ -38,12 +38,13 @@
  */
 
 import { CommonModule } from '@angular/common';
-import { APP_INITIALIZER, NgModule } from '@angular/core';
+import { APP_INITIALIZER, ModuleWithProviders, NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { IonicModule } from '@ionic/angular';
 import { TranslateModule } from '@ngx-translate/core';
 import { ProjectModuleService } from '@multi/shared';
 import { ImportantNewsComponent } from './widgets/important-news/important-news.component';
+import { IMPORTANT_NEWS_CONFIG, ImportantNewsModuleConfig } from './important-news.config';
 
 const initModule = (projectModuleService: ProjectModuleService) =>
   () => projectModuleService.initProjectModule({
@@ -72,4 +73,13 @@ const initModule = (projectModuleService: ProjectModuleService) =>
 })
 export class ImportantNewsModule {
   static routerLink = '/important-news';
+
+  static forRoot(config: ImportantNewsModuleConfig): ModuleWithProviders<ImportantNewsModule> {
+    return {
+      ngModule: ImportantNewsModule,
+      providers: [
+        { provide: IMPORTANT_NEWS_CONFIG, useValue: config }
+      ]
+    };
+  }
  }

--- a/dev/user-frontend-ionic/projects/important-news/src/lib/widgets/important-news/important-news.component.html
+++ b/dev/user-frontend-ionic/projects/important-news/src/lib/widgets/important-news/important-news.component.html
@@ -41,19 +41,23 @@
   <ion-spinner class="safe-area-lr-ionic-margin" name="dots"></ion-spinner>
 </ion-row>
 <ng-container *ngIf="isLoading === false && randomImportantNews$ | async as randomImportantNews">
-  <ion-grid class="border ion-no-padding">
+  <ion-grid class="border ion-no-padding" 
+  [ngClass]="{'important-news-vertically-style': config.display === 'vertically', 
+              'important-news-horizontally-style': config.display === 'horizontally'}">
     <ion-row [ngStyle]="{'background-color': randomImportantNews.color}">
       <ion-col>
         <ion-row class="importantNews">
-          <ion-col *ngIf="randomImportantNews.image">
+          <ion-col *ngIf="randomImportantNews.image" [size]="config.display === 'vertically' ? '6' : '12'"
+            class="img-container">
             <ion-img [src]="cmsPublicAssetsEndpoint + randomImportantNews.image"></ion-img>
           </ion-col>
-          <ion-col class="border-bottom news-content" [size]="randomImportantNews.image ? '6' : '12'"
+          <ion-col class="border-bottom news-content" 
+          [size]="randomImportantNews.image && config.display === 'vertically' ? '6' : '12'"
           [ngClass]="{'without-image': !randomImportantNews.image}">
             <ion-label class="ion-text-wrap text-title" >
               <h2 [ngClass]="fontColor(randomImportantNews.color)" class="app-title-5">{{ randomImportantNews.title }}</h2>
             </ion-label>
-            <ion-label class="ion-text-wrap text-content">
+            <ion-label *ngIf="randomImportantNews.content" class="ion-text-wrap text-content">
               <h3 [ngClass]="fontColor(randomImportantNews.color)" class="app-text-4">{{randomImportantNews.content}}</h3>
             </ion-label>
             <ion-row *ngIf="randomImportantNews.link" class="ion-justify-content-end">

--- a/dev/user-frontend-ionic/projects/important-news/src/lib/widgets/important-news/important-news.component.ts
+++ b/dev/user-frontend-ionic/projects/important-news/src/lib/widgets/important-news/important-news.component.ts
@@ -46,6 +46,7 @@ import { finalize, map, take } from 'rxjs/operators';
 import { ImportantNews, importantNewsList$, setImportantNews as setImportantNewsList } from '../../important-news.repository';
 import { ImportantNewsService } from '../../important-news.service';
 import { TranslatedImportantNews } from '../../important-news.repository';
+import { IMPORTANT_NEWS_CONFIG, ImportantNewsModuleConfig } from '../../important-news.config';
 
 
 @Component({
@@ -70,7 +71,8 @@ export class ImportantNewsComponent {
     private importantNewsService: ImportantNewsService,
     private router: Router,
     private statisticsService: StatisticsService,
-    private themeService: ThemeService
+    private themeService: ThemeService,
+    @Inject(IMPORTANT_NEWS_CONFIG) public config: ImportantNewsModuleConfig
   ) {
     this.isEmpty$ = this.importantNewsList$.pipe(
       map(importantNewsList => !importantNewsList || importantNewsList.length === 0)

--- a/dev/user-frontend-ionic/src/environments/environment.ts.dist
+++ b/dev/user-frontend-ionic/src/environments/environment.ts.dist
@@ -83,7 +83,9 @@ export const environment: any = {
     ClockingModule,
     ContactUsModule,
     ContactsModule.forRoot({ contactTypes: ['STUDENT', 'STAFF', 'STANDIN'] }),
-    ImportantNewsModule,
+    ImportantNewsModule.forRoot({
+      display: 'vertically'
+    }),
     MapModule.forRoot({
       defaultMapLocation: {
         longitude: 2.3488596,


### PR DESCRIPTION
Bonjour,

Voilà la contribution de l'UPHF pour important news.

Nous avons ajouté une vue alternative du widget important news. Celle-ci affiche la news avec une division verticale (image à gauche, texte à droite), ou horizontale (image en haut, texte en bas). Il n'y avait pas de module de configuration pour important news, nous avons donc dû le créer.

Bonne fin de journée