### PR TITLE
MULTI-2350: upgrade ionicons pour logo X

### DIFF
--- a/dev/user-frontend-ionic/package-lock.json
+++ b/dev/user-frontend-ionic/package-lock.json
@@ -54,7 +54,7 @@
         "firebase": "^10.4.0",
         "fullcalendar": "^6.0.0",
         "geolib": "^3.3.3",
-        "ionicons": "^6.0.3",
+        "ionicons": "^7.4.0",
         "leaflet": "^1.9.2",
         "localforage": "^1.10.0",
         "lodash": "^4.17.21",
@@ -3995,13 +3995,6 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/@ionic/angular/node_modules/ionicons": {
-      "version": "7.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "@stencil/core": "^2.18.0"
-      }
-    },
     "node_modules/@ionic/cli-framework-output": {
       "version": "2.2.5",
       "license": "MIT",
@@ -4021,17 +4014,6 @@
         "@stencil/core": "^4.1.0",
         "ionicons": "7.1.0",
         "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@ionic/core/node_modules/@stencil/core": {
-      "version": "4.2.0",
-      "license": "MIT",
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.10.0"
       }
     },
     "node_modules/@ionic/core/node_modules/ionicons": {
@@ -5271,14 +5253,15 @@
       "dev": true
     },
     "node_modules/@stencil/core": {
-      "version": "2.22.2",
-      "license": "MIT",
+      "version": "4.18.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.18.3.tgz",
+      "integrity": "sha512-8yoG5AFQYEPocVtuoc5kvRS0Hku0MoDWDUpADRaXPVHsOFLmxR16LJENj25ucCz5GEfeTGQ/tCE8JAypPmr/fQ==",
       "bin": {
         "stencil": "bin/stencil"
       },
       "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
+        "node": ">=16.0.0",
+        "npm": ">=7.10.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -11347,10 +11330,11 @@
       }
     },
     "node_modules/ionicons": {
-      "version": "6.1.1",
-      "license": "MIT",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.4.0.tgz",
+      "integrity": "sha512-ZK94MMqgzMCPPMhmk8Ouu6goyVHFIlw/ACP6oe3FrikcI0N7CX0xcwVaEbUc0G/v3W0shI93vo+9ve/KpvcNhQ==",
       "dependencies": {
-        "@stencil/core": "^2.18.0"
+        "@stencil/core": "^4.0.3"
       }
     },
     "node_modules/ip": {
@@ -22353,14 +22337,6 @@
         "ionicons": "^7.0.0",
         "jsonc-parser": "^3.0.0",
         "tslib": "^2.3.0"
-      },
-      "dependencies": {
-        "ionicons": {
-          "version": "7.1.2",
-          "requires": {
-            "@stencil/core": "^2.18.0"
-          }
-        }
       }
     },
     "@ionic/angular-toolkit": {
@@ -22453,9 +22429,6 @@
         "tslib": "^2.1.0"
       },
       "dependencies": {
-        "@stencil/core": {
-          "version": "4.2.0"
-        },
         "ionicons": {
           "version": "7.1.0",
           "requires": {
@@ -23309,7 +23282,9 @@
       "dev": true
     },
     "@stencil/core": {
-      "version": "2.22.2"
+      "version": "4.18.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.18.3.tgz",
+      "integrity": "sha512-8yoG5AFQYEPocVtuoc5kvRS0Hku0MoDWDUpADRaXPVHsOFLmxR16LJENj25ucCz5GEfeTGQ/tCE8JAypPmr/fQ=="
     },
     "@tootallnate/once": {
       "version": "2.0.0",
@@ -27419,9 +27394,11 @@
       }
     },
     "ionicons": {
-      "version": "6.1.1",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.4.0.tgz",
+      "integrity": "sha512-ZK94MMqgzMCPPMhmk8Ouu6goyVHFIlw/ACP6oe3FrikcI0N7CX0xcwVaEbUc0G/v3W0shI93vo+9ve/KpvcNhQ==",
       "requires": {
-        "@stencil/core": "^2.18.0"
+        "@stencil/core": "^4.0.3"
       }
     },
     "ip": {

--- a/dev/user-frontend-ionic/package.json
+++ b/dev/user-frontend-ionic/package.json
@@ -69,7 +69,7 @@
     "firebase": "^10.4.0",
     "fullcalendar": "^6.0.0",
     "geolib": "^3.3.3",
-    "ionicons": "^6.0.3",
+    "ionicons": "^7.4.0",
     "leaflet": "^1.9.2",
     "localforage": "^1.10.0",
     "lodash": "^4.17.21",

--- a/env/local/docker/directus/directus/data/social_networks.json
+++ b/env/local/docker/directus/directus/data/social_networks.json
@@ -7,7 +7,7 @@
 	},
 	{
 		"title": "X",
-		"icon": "logo-twitter",
+		"icon": "logo-x",
 		"link": "https://x.com/EsupPortail",
 		"sort": 2
 	},


### PR DESCRIPTION
https://gesproj.univ-lorraine.fr/plugins/tracker/?aid=2350

Le nouveau logo de X (Twitter) est disponible depuis la version 7.4.0 d'_ionicons_ (actuellement la dernière). On passe donc à cette version, toujours compatible node 16.
Il y a un changement majeur de version mais normalement on avait déjà résolu le problème avec la question de l'accessibilité.

> [!NOTE]
> Il faudra remplacer `logo-twitter` par `logo-x` dans le CMS