### PR TITLE
fix(@multi-frontend/schedule): couleurs widget

### DIFF
--- a/dev/user-frontend-ionic/projects/schedule/src/lib/widgets/next-events/next-events.component.html
+++ b/dev/user-frontend-ionic/projects/schedule/src/lib/widgets/next-events/next-events.component.html
@@ -74,7 +74,7 @@
                 class="app-title-5">{{event.course.label}}</ion-text>
               <ion-row>
                 <ion-row class="ion-align-items-center card-labels" *ngFor="let room of event.rooms">
-                  <ion-icon class="card-labels-icons" name="business-outline" aria-label=""></ion-icon>
+                  <ion-icon [ngClass]="[fontColor(), 'card-labels-icons']" name="business-outline" aria-label=""></ion-icon>
                   <ion-text [ngClass]="fontColor()"
                     class="app-title-6 light">{{room.label}} - {{room.building}}</ion-text>
                 </ion-row>

--- a/dev/user-frontend-ionic/src/theme/app-theme-dist/styles/schedule/next-events.component.scss
+++ b/dev/user-frontend-ionic/src/theme/app-theme-dist/styles/schedule/next-events.component.scss
@@ -75,7 +75,6 @@ padding-bottom: 0rem !important;
   padding-bottom: 0.5rem !important;
   padding-top: 0.5rem !important;
   padding-left: 0rem !important;
-  background-color: var(--ion-color-quaternary) !important;
   z-index: 12;
 }
 


### PR DESCRIPTION
https://gesproj.univ-lorraine.fr/plugins/tracker/?aid=5310

Problèmes de couleurs sur le widget schedule :
- mauvaise couleur icône batiment
- couleur de fond indésirable sur la date
