### PR TITLE
fix(@multi-frontend/cards): fermeture modal popup

### DIFF
--- a/dev/user-frontend-ionic/projects/cards/src/lib/card/card-modal.component.html
+++ b/dev/user-frontend-ionic/projects/cards/src/lib/card/card-modal.component.html
@@ -37,7 +37,7 @@
   ~ termes.
   -->
 
-<ion-modal [isOpen]="isModalOpen">
+<ion-modal [isOpen]="isModalOpen" (willDismiss)="onWillDismiss()">
   <ng-template>
     <ion-header>
       <ion-toolbar class="app-toolbar-as-on-page">

--- a/dev/user-frontend-ionic/projects/cards/src/lib/card/card-modal.component.ts
+++ b/dev/user-frontend-ionic/projects/cards/src/lib/card/card-modal.component.ts
@@ -76,8 +76,16 @@ export class CardModalComponent implements OnInit, OnDestroy {
     this.isModalOpen = true;
   }
 
-  closeModal = () => {
+  /**
+   * Close the modal
+   * Will trigger the onWillDismiss event
+   */
+  closeModal() {
+    this.isModalOpen = false;
+  }
+
+  onWillDismiss() {
     this.screenService.restorePreviousBrightness();
     this.isModalOpen = false;
-  };
+  }
 }


### PR DESCRIPTION
https://gesproj.univ-lorraine.fr/plugins/tracker/?aid=3514

L'évènement de fermeture n'était pas écouté. 
Il était alors impossible de rouvrir la modale si fermée en appuyant en dehors de l'écran (sur grand écran, tablette ou pc).