### PR TITLE
fix(@multi-frontend): state Elf qui n'était plus sauvegardé

### DIFF
--- a/dev/user-frontend-ionic/projects/auth/src/lib/common/login.repository.ts
+++ b/dev/user-frontend-ionic/projects/auth/src/lib/common/login.repository.ts
@@ -39,7 +39,8 @@
 
 import { Inject, Injectable } from '@angular/core';
 import { createStore, select, withProps } from '@ngneat/elf';
-import { currentLanguage$ } from '@multi/shared';
+import { persistState } from '@ngneat/elf-persist-state';
+import { currentLanguage$, localForageStore } from '@multi/shared';
 import { combineLatest } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
@@ -73,6 +74,11 @@ const store = createStore(
   { name: STORE_NAME },
   withProps<LoginProps>({ pageContent: null })
 );
+
+export const persist = persistState(store, {
+  key: STORE_NAME,
+  storage: localForageStore,
+});
 
 @Injectable({ providedIn: 'root' })
 export class LoginRepository {

--- a/dev/user-frontend-ionic/projects/contact-us/src/lib/contact-us.repository.ts
+++ b/dev/user-frontend-ionic/projects/contact-us/src/lib/contact-us.repository.ts
@@ -39,7 +39,8 @@
 
 import { Inject, Injectable } from '@angular/core';
 import { createStore, select, withProps } from '@ngneat/elf';
-import { currentLanguage$ } from '@multi/shared';
+import { persistState } from '@ngneat/elf-persist-state';
+import { currentLanguage$, localForageStore } from '@multi/shared';
 import { combineLatest } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
@@ -72,6 +73,11 @@ const store = createStore(
   { name: STORE_NAME },
   withProps<ContactUsProps>({ pageContent: null })
 );
+
+export const persist = persistState(store, {
+  key: STORE_NAME,
+  storage: localForageStore,
+});
 
 @Injectable({ providedIn: 'root' })
 export class ContactUsRepository {

--- a/dev/user-frontend-ionic/projects/shared/src/lib/auth/authenticated-user.repository.ts
+++ b/dev/user-frontend-ionic/projects/shared/src/lib/auth/authenticated-user.repository.ts
@@ -38,6 +38,8 @@
  */
 
 import { createStore, select, withProps } from '@ngneat/elf';
+import { persistState } from '@ngneat/elf-persist-state';
+import { localForageStore } from '../store/local-forage';
 
 const STORE_NAME = 'auth';
 
@@ -58,6 +60,11 @@ const authStore = createStore(
   { name: STORE_NAME },
   withProps<AuthProps>({ authenticatedUser: null })
 );
+
+export const persist = persistState(authStore, {
+  key: STORE_NAME,
+  storage: localForageStore,
+});
 
 export const authenticatedUser$ = authStore.pipe(select((state) => state.authenticatedUser));
 

--- a/dev/user-frontend-ionic/projects/shared/src/lib/auth/authenticated-username.repository.ts
+++ b/dev/user-frontend-ionic/projects/shared/src/lib/auth/authenticated-username.repository.ts
@@ -38,19 +38,26 @@
  */
 
 import { createStore, select, withProps } from '@ngneat/elf';
+import {
+  persistState,
+  localStorageStrategy
+} from '@ngneat/elf-persist-state';
 
 const STORE_NAME = 'auth-username';
-
 
 interface AuthProps {
   username: string;
 }
 
-
 const authStore = createStore(
   { name: STORE_NAME },
   withProps<AuthProps>({ username: null })
 );
+
+export const persist = persistState(authStore, {
+  key: STORE_NAME,
+  storage: localStorageStrategy,
+});
 
 export const authenticatedUsername$ = authStore.pipe(select((state) => state.username));
 

--- a/dev/user-frontend-ionic/projects/shared/src/lib/guided-tour/guided-tour.repository.ts
+++ b/dev/user-frontend-ionic/projects/shared/src/lib/guided-tour/guided-tour.repository.ts
@@ -38,6 +38,8 @@
  */
 
 import { createStore, setProps, withProps } from '@ngneat/elf';
+import { persistState } from '@ngneat/elf-persist-state';
+import { localForageStore } from '../store/local-forage';
 
 const STORE_NAME = 'guided-tour';
 
@@ -55,6 +57,11 @@ const store = createStore(
     scheduleTourViewed: false
   })
 );
+
+export const persist = persistState(store, {
+  key: STORE_NAME,
+  storage: localForageStore,
+});
 
 export const isAnonymousTourViewed = () => store.getValue()?.anonymousTourViewed;
 export const isLoggedTourViewed = () => store.getValue()?.loggedTourViewed;

--- a/dev/user-frontend-ionic/projects/shared/src/lib/i18n/i18n.repository.ts
+++ b/dev/user-frontend-ionic/projects/shared/src/lib/i18n/i18n.repository.ts
@@ -38,6 +38,8 @@
  */
 
 import { createStore, select, withProps } from '@ngneat/elf';
+import { persistState } from '@ngneat/elf-persist-state';
+import { localForageStore } from '../store/local-forage';
 
 const STORE_NAME = 'i18n';
 
@@ -51,6 +53,11 @@ const store = createStore(
     language: null,
   })
 );
+
+export const persist = persistState(store, {
+  key: STORE_NAME,
+  storage: localForageStore,
+});
 
 export const currentLanguage$ = store.pipe(select((state) => state.language));
 


### PR DESCRIPTION
Une mise à jour de lint nous a fait retirer par inadvertance les fonctions persistState() dans les différents fichiers repository des modules du client.
Ces fonctions ont été rétablies.