### PR TITLE
fix(@multi-frontend/guided-tour): chargement des traductions avant debut tour guide

### DIFF
--- a/dev/user-frontend-ionic/projects/shared/src/lib/guided-tour/guided-tour.service.ts
+++ b/dev/user-frontend-ionic/projects/shared/src/lib/guided-tour/guided-tour.service.ts
@@ -43,7 +43,7 @@ import { Capacitor } from '@capacitor/core';
 import { OrientationType, ScreenOrientation } from '@capawesome/capacitor-screen-orientation';
 import { TranslateService } from '@ngx-translate/core';
 import { ShepherdService } from 'angular-shepherd';
-import { Observable } from 'rxjs';
+import { Observable, zip } from 'rxjs';
 import { filter, switchMap, take } from 'rxjs/operators';
 import { userIsAuthenticated$ } from '../auth/authenticated-user.repository';
 import { MenuItem } from '../navigation/menu.model';
@@ -90,13 +90,14 @@ export class GuidedTourService {
       return;
     }
 
-    this.isOnline$
-      .pipe(
+    zip(
+      this.isOnline$.pipe(
         filter(isOnline => isOnline),
         take(1),
-        switchMap(() => userIsAuthenticated$.pipe(take(1)))
-      )
-      .subscribe(userIsAuthenticated => {
+        switchMap(() => userIsAuthenticated$.pipe(take(1))),
+      ),
+      this.translateService.get('GUIDED_TOUR') // on ne le récupère pas, mais permet d'attendre que la traduction soit chargée, sinon .instant() ne fonctionne pas à chaque fois
+    ).subscribe(([userIsAuthenticated]) => {
         if (
           !isLoggedTourViewed() &&
           !isAnonymousTourViewed() &&


### PR DESCRIPTION
## Checklist de PR
Veuillez vérifier que votre PR respecte bien les indications suivantes :

- [x] Votre PR pointe vers la branche `develop`
- [x] Votre PR suit les différentes étapes du guide de contribution : https://www.esup-portail.org/wiki/x/KQCeUQ
- [x] Les modifications ont été testées de votre côté, cela implique également des tests sur des périphériques (iOS + Android) si le client a évolué
- [x] La documentation a été mise à jour et prend en compte les changements (fichiers README, Wiki Esup)

## Type de PR
Quel type de changement concerne cette PR ?

- [x] Bug Fix
- [ ] Nouvelle Feature
- [ ] Mise à jour de la documentation (README, CHANGELOG, CONTRIBUTING)
- [ ] Style (SCSS, Assets)
- [ ] Refactoring de code
- [ ] Ajout de tests
- [ ] Build (scripts npm, .sh)
- [ ] CI
- [ ] Chore (nouvelle Release, maj de dépendances)
- [ ] Revert

## Quel est le comportement actuel ?
Parfois, le texte du tour guidé n'est pas traduit. La clef de la traduction s'affiche à la place.

Lien vers l'issue :
https://gesproj.univ-lorraine.fr/plugins/tracker/?aid=3062

## Quel est le nouveau comportement ?
`translateService.translations` est bien complet, mais `translateService.instant(KEY.X.Y)` ne trouve pas la traduction correspondante.
On s'assure donc que les traductions sont chargées en faisant un `translateService.get(KEY)` avant le lancement du tour guidé.

## Cette PR implique un Breaking Change ?
- [ ] Oui
- [x] Non

## Information complémentaire
RAS
