### PR TITLE
fix(@multi-frontend/shared): accueil vide au premier lancement

### DIFF
--- a/dev/user-frontend-ionic/projects/shared/src/lib/features/features.service.ts
+++ b/dev/user-frontend-ionic/projects/shared/src/lib/features/features.service.ts
@@ -97,6 +97,7 @@ export class FeaturesService {
       isFeatureStoreInitialized$.pipe(filter(initialized => initialized === true))
     ])
       .pipe(
+        filter(([features]) => features.length > 0),
         map(([features, currentLanguage]) => this.translate(features, currentLanguage)),
         share(),
       ).subscribe(this.translatedFeaturesSubject$);


### PR DESCRIPTION
Bonjour,

Voici un PR pour corriger un problème d'affichage de l'écran d'accueil lors du tout premier lancement de l'application dans certains cas.

Bonne fin de journée

------------------

## Checklist de PR

Veuillez vérifier que votre PR respecte bien les indications suivantes :

- [X] Votre PR pointe vers la branche `develop`
- [X] Votre PR suit les différentes étapes du guide de contribution : https://www.esup-portail.org/wiki/x/KQCeUQ
- [X] Les modifications ont été testées de votre côté, cela implique également des tests sur des périphériques (iOS + Android) si le client a évolué
- [ ] La documentation a été mise à jour et prend en compte les changements (fichiers README, Wiki Esup)

## Type de PR

Quel type de changement concerne cette PR ?

- [X] Bug Fix
- [ ] Nouvelle Feature
- [ ] Mise à jour de la documentation (README, CHANGELOG, CONTRIBUTING)
- [ ] Style (SCSS, Assets)
- [ ] Refactoring de code
- [ ] Ajout de tests
- [ ] Build (scripts npm, .sh)
- [ ] CI
- [ ] Chore (nouvelle Release, maj de dépendances)
- [ ] Revert

## Cette PR implique un Breaking Change ?
- [ ] Oui
- [X] Non
