### PR TITLE
fix(@multi-frontend): problème widgets parfois vides

### DIFF
--- a/dev/user-frontend-ionic/projects/auth/src/lib/login/login.page.ts
+++ b/dev/user-frontend-ionic/projects/auth/src/lib/login/login.page.ts
@@ -41,7 +41,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { IonInput, ToastController } from '@ionic/angular';
-import { AuthenticatedUser, NavigationService } from '@multi/shared';
+import { AuthenticatedUser, FeaturesService, NavigationService } from '@multi/shared';
 import { Observable } from 'rxjs';
 import { finalize, take, tap } from 'rxjs/operators';
 import { AuthService } from '../common/auth.service';
@@ -78,7 +78,8 @@ export class LoginPage implements OnInit {
     private loginRepository: LoginRepository,
     private route: ActivatedRoute,
     private router: Router,
-    private navigationService: NavigationService
+    private navigationService: NavigationService,
+    private featuresService: FeaturesService
   ) {
     this.translatedPageContent$ = this.loginRepository.translatedPageContent$;
     this.hideBackButton$ = this.navigationService.isExternalNavigation$;
@@ -149,12 +150,13 @@ export class LoginPage implements OnInit {
         }
         this.authService.dispatchLoginAction();
 
-        if (this.returnUrl) {
-          this.router.navigateByUrl(this.returnUrl);
-          return;
-        }
-
-        this.router.navigate(['/features/widgets']);
+        this.featuresService.loadAndStoreFeatures().subscribe(() => {
+          if (this.returnUrl) {
+            this.router.navigateByUrl(this.returnUrl);
+          } else {
+            this.router.navigate(['/features/widgets']);
+          }
+        });
       });
   }
 

--- a/dev/user-frontend-ionic/projects/auth/src/lib/preferences/preferences.service.ts
+++ b/dev/user-frontend-ionic/projects/auth/src/lib/preferences/preferences.service.ts
@@ -64,8 +64,10 @@ export class PreferencesService {
         return getRefreshAuthToken().pipe(
             take(1),
             filter(token => token != null),
-            concatMap(token => this.keepAuthService.removeSavedCredentials(token)),
-            finalize(() => deleteRefreshAuthToken())
+            concatMap(token =>
+              this.keepAuthService.removeSavedCredentials(token).pipe(
+                finalize(() => deleteRefreshAuthToken())
+              )),
         ).subscribe();
     }
 }

--- a/dev/user-frontend-ionic/projects/shared/src/lib/auth/auth.repository.ts
+++ b/dev/user-frontend-ionic/projects/shared/src/lib/auth/auth.repository.ts
@@ -39,7 +39,7 @@
 
 import { SecureStoragePlugin } from 'capacitor-secure-storage-plugin';
 import { from, Observable, of } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { catchError, map, switchMap } from 'rxjs/operators';
 
 const AUTH_TOKEN_KEY = 'auth-token';
 
@@ -53,14 +53,45 @@ export const updateAuthToken = (token: string): Observable<boolean> => from(
     );
 
 export const getAuthToken = (): Observable<string | null> => from(
-    SecureStoragePlugin.get({key: AUTH_TOKEN_KEY}))
-    .pipe(
-        map(result => result.value),
-        catchError(() => of(null)),
-    );
+  SecureStoragePlugin.keys()).pipe(
+  map(result => result.value),
+  switchMap(keys => {
+    // On vérifie l'existence de la clé avant suppression pour éviter de tomber dans le catch de l'erreur du plugin
+    // https://github.com/martinkasa/capacitor-secure-storage-plugin/issues/39
+    if (keys.includes(AUTH_TOKEN_KEY)) {
+      return from(SecureStoragePlugin.get({key: AUTH_TOKEN_KEY}))
+        .pipe(
+          map(result => result.value),
+          catchError(() => {
+            return of(null)
+          }));
+    } else {
+      return of(null);
+    }
+  }),
+  catchError(() => of(null))
+);
 
 export const deleteAuthToken = (): Observable<boolean> => from(
-    SecureStoragePlugin.remove({key: AUTH_TOKEN_KEY}))
-    .pipe(
-        map(result => result.value)
-    );
+  SecureStoragePlugin.keys()).pipe(
+  map(result => result.value),
+  switchMap(keys => {
+    // On vérifie l'existence de la clé avant suppression pour éviter de tomber dans le catch de l'erreur du plugin
+    // https://github.com/martinkasa/capacitor-secure-storage-plugin/issues/39
+    if (keys.includes(AUTH_TOKEN_KEY)) {
+      return from(
+        SecureStoragePlugin.remove({key: AUTH_TOKEN_KEY}))
+        .pipe(
+          map(result => result.value),
+          catchError(() => {
+            return of(null)
+          }));
+    } else {
+      return of(null);
+    }
+  }),
+  catchError(() => of(null))
+);
+
+
+

--- a/dev/user-frontend-ionic/projects/shared/src/lib/components/widgets/widget-lifecycle.service.ts
+++ b/dev/user-frontend-ionic/projects/shared/src/lib/components/widgets/widget-lifecycle.service.ts
@@ -38,7 +38,7 @@
  */
 
 import { Injectable } from '@angular/core';
-import { Observable, Subject } from 'rxjs';
+import { Observable, ReplaySubject, Subject } from 'rxjs';
 import { filter, shareReplay } from 'rxjs/operators';
 
 /**
@@ -54,9 +54,9 @@ import { filter, shareReplay } from 'rxjs/operators';
 })
 export class WidgetLifecycleService {
   private widgetViewWillEnterSubject: Subject<string[]> = new Subject();
-  private widgetViewDidEnterSubject: Subject<string[]> = new Subject();
+  private widgetViewDidEnterSubject: ReplaySubject<string[]> = new ReplaySubject<string[]>(1);
   private widgetViewWillLeaveSubject: Subject<string[]> = new Subject();
-  private widgetViewDidLeaveSubject: Subject<string[]> = new Subject();
+  private widgetViewDidLeaveSubject: ReplaySubject<string[]> = new ReplaySubject<string[]>(1);
 
   sendWidgetViewWillEnter(widgets) {
     this.widgetViewWillEnterSubject.next(widgets);

--- a/dev/user-frontend-ionic/src/app/app.component.html
+++ b/dev/user-frontend-ionic/src/app/app.component.html
@@ -37,19 +37,21 @@
   ~ termes.
   -->
 
-<ion-app *ngIf="(currentPageLayout$ | async) as currentPageLayout">
+<ion-app *ngIf="(currentPageLayout$ | async) as currentPageLayout; else noContent">
   <app-layout [currentPageLayout]='currentPageLayout'></app-layout>
 </ion-app>
 
-<div *ngIf="(isNothingToShow$ | async) === true" class="custom-alert">
-  <div class="flex-container">
-    <ion-card class="center-card">
-      <ion-card-header>
-        <ion-card-title class="text-center app-title-4">{{"ERROR.NO_NETWORK.TITLE" | translate}}</ion-card-title>
-      </ion-card-header>
-      <ion-card-content>
-        <ion-text class="app-text-4">{{"ERROR.NO_NETWORK.FIRST_LAUNCH" | translate}}</ion-text>
-      </ion-card-content>
-    </ion-card>
+<ng-template #noContent>
+  <div *ngIf="(isNothingToShow$ | async) === true" class="custom-alert">
+    <div class="flex-container">
+      <ion-card class="center-card">
+        <ion-card-header>
+          <ion-card-title class="text-center app-title-4">{{"ERROR.NO_NETWORK.TITLE" | translate}}</ion-card-title>
+        </ion-card-header>
+        <ion-card-content>
+          <ion-text class="app-text-4">{{"ERROR.NO_NETWORK.FIRST_LAUNCH" | translate}}</ion-text>
+        </ion-card-content>
+      </ion-card>
+    </div>
   </div>
-</div>
+</ng-template>

--- a/dev/user-frontend-ionic/src/app/app.component.ts
+++ b/dev/user-frontend-ionic/src/app/app.component.ts
@@ -54,8 +54,8 @@ import {
   themeRepoInitialized$, userHadSetThemeInApp, userHadSetThemeInApp$
 } from '@multi/shared';
 import { initializeApp } from 'firebase/app';
-import { combineLatest, Observable, of, Subscription } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
+import { combineLatest, Observable, of, Subject } from 'rxjs';
+import { distinctUntilChanged, filter, map, switchMap, takeUntil } from 'rxjs/operators';
 import { Title } from '@angular/platform-browser';
 
 @Component({
@@ -64,15 +64,14 @@ import { Title } from '@angular/platform-browser';
   styleUrls: ['../theme/app-theme/styles/app/app.component.scss'],
 })
 export class AppComponent implements OnInit, OnDestroy {
-
   public languages: Array<string> = [];
   public currentPageLayout$: Observable<PageLayout>;
   public isOnline$: Observable<boolean>;
   public isNothingToShow$: Observable<boolean>;
-  private featuresIsEmpty$: Observable<boolean>;
-  private subscriptions: Subscription[] = [];
   private backButtonListener: Promise<PluginListenerHandle>;
   private appResumeListener: Promise<PluginListenerHandle>;
+  private destroy$ = new Subject<void>();
+  private prefersDark: MediaQueryList;
 
   constructor(
     @Inject('environment')
@@ -91,149 +90,151 @@ export class AppComponent implements OnInit, OnDestroy {
     private statisticsService: StatisticsService,
     private titleService: Title
   ) {
-    currentLanguage$.subscribe((language) => {
-      document.documentElement.lang = language || environment.defaultLanguage;
-    });
-
-    this.featuresIsEmpty$ = features$.pipe(
-      map((val) => val.length === 0)
-    );
-
-    this.isNothingToShow$ = isFeatureStoreInitialized$.pipe(
-      switchMap(isInitialized => {
-        if (isInitialized) {
-          return combineLatest([
-            this.featuresIsEmpty$,
-            this.networkService.isOnline$
-          ]);
-        } else {
-          return of([null, null]);
-        }
-      }),
-      switchMap(([featuresIsEmpty, isOnline]) => {
-        const nothingToShowButLoadFeatures = featuresIsEmpty && isOnline;
-        const isNothingToShow = (featuresIsEmpty === true || featuresIsEmpty === null) && (isOnline === false || isOnline === null);
-
-        if (nothingToShowButLoadFeatures) {
-          return this.featuresService.loadAndStoreFeatures().pipe(
-            map(() => true)
-          );
-        } else {
-          return of(isNothingToShow);
-        }
-      }));
-
-    this.isNothingToShow$.subscribe();
-
-    SplashScreen.show({
-      showDuration: 1500,
-      autoHide: true,
-      fadeInDuration: 500
-    });
-
-    // Define available languages in app
-    this.languages = this.environment.languages;
-    this.translateService.addLangs(this.languages);
-
-    this.currentPageLayout$ = this.pageLayoutService.currentPageLayout$;
-
-    this.platform.ready().then(() => {
-      if (!Capacitor.isNativePlatform()) {
-        return;
-      }
-
-      StatusBar.setStyle({ style: Style.Dark });
-    });
-
-    this.statisticsService.checkAndGenerateStatsUid();
+    this.initializeApp();
   }
 
   ngOnInit() {
     this.titleService.setTitle(this.environment.appTitle);
-    this.backButtonListener = App.addListener('backButton', () => {
-      this.popoverController.getTop().then(popover => {
-        if (popover) {
-          popover.dismiss();
-          return;
-        }
-        this.modalController.getTop().then(modal => {
-          if (modal) {
-            modal.dismiss();
-            return;
-          }
-          this.navigationService.navigateBack();
-        });
-      });
-    });
+    this.initializeBackButton();
+    this.initializeAppResume();
+    this.initializeTheme();
+    this.handleBadge();
 
+    if (!Capacitor.isNativePlatform()) {
+      this.initializeFirebase();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+    this.backButtonListener.then((listener) => listener.remove());
+    this.appResumeListener.then((listener) => listener.remove());
+    this.prefersDark.removeEventListener('change', this.handleColorSchemeChange);
+  }
+
+  private initializeBackButton(): void {
+    this.backButtonListener = App.addListener('backButton', this.handleBackButton.bind(this));
+  }
+
+  private async handleBackButton(): Promise<void> {
+    const popover = await this.popoverController.getTop();
+    if (popover) {
+      await popover.dismiss();
+      return;
+    }
+    const modal = await this.modalController.getTop();
+    if (modal) {
+      await modal.dismiss();
+      return;
+    }
+    this.navigationService.navigateBack();
+  }
+
+  private initializeAppResume(): void {
     // reload notifications when app is resumed (back to foreground)
     this.appResumeListener = App.addListener('resume', () => {
       this.notificationsService.loadNotifications(0, 10).subscribe();
     });
+  }
 
-    // apply language saved in persistent state
-    this.subscriptions.push(currentLanguage$
-      .subscribe(language => this.translateService.use(language || this.environment.defaultLanguage))
-    );
-
-    // apply theme saved in persistent state or if is not in the system setting of the user's device
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
-    prefersDark.removeEventListener('change', (mediaQuery) => this.toggleOSDarkTheme(mediaQuery.matches));
-    // Listen for changes to the prefers-color-scheme media query (from system setting of the user)
-    prefersDark.addEventListener('change', (mediaQuery) => this.toggleOSDarkTheme(mediaQuery.matches));
+  private initializeTheme(): void {
+    this.prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+    this.prefersDark.addEventListener('change', this.handleColorSchemeChange);
 
     themeRepoInitialized$.pipe(
-      switchMap(isInitialized => isInitialized ? combineLatest([isDarkTheme$, userHadSetThemeInApp$])
-        : of(null)),
+      filter(isInitialized => isInitialized),
+      switchMap(() => combineLatest([isDarkTheme$, userHadSetThemeInApp$])),
+      takeUntil(this.destroy$)
     ).subscribe(([isDarkTheme, userHadSetThemeInApplication]) => {
-      if (userHadSetThemeInApplication === false && prefersDark.matches) {
-        isDarkTheme = true;
-        setIsDarkTheme(true);
+      if (!userHadSetThemeInApplication) {
+        isDarkTheme = this.prefersDark.matches;
+        setIsDarkTheme(isDarkTheme);
       }
-
-      if (userHadSetThemeInApplication === false && !prefersDark.matches) {
-        isDarkTheme = false;
-        setIsDarkTheme(false);
-      }
-
       this.toggleDarkTheme(isDarkTheme);
     });
-
-    this.initializeFirebase();
-    this.handleBadge();
   }
 
-  toggleDarkTheme(isDarkTheme: boolean): void {
-    const body = document.body;
-    if (isDarkTheme) {
-      this.renderer.addClass(body, 'dark');
-    } else {
-      this.renderer.removeClass(body, 'dark');
-    }
-  }
-
-  toggleOSDarkTheme(shouldAdd) {
+  private handleColorSchemeChange(mediaQuery: MediaQueryListEvent): void {
     if (!userHadSetThemeInApp()) {
+      const shouldAdd = mediaQuery.matches;
       setIsDarkTheme(shouldAdd);
       this.toggleDarkTheme(shouldAdd);
     }
   }
 
-  ngOnDestroy(): void {
-    this.subscriptions.forEach(s => s.unsubscribe());
-    this.backButtonListener.then((listener) => {
-      listener.remove();
+  private toggleDarkTheme(isDarkTheme: boolean): void {
+    this.renderer[isDarkTheme ? 'addClass' : 'removeClass'](document.body, 'dark');
+  }
+
+  private initializeApp(): void {
+    this.initializeLanguage();
+    this.initializeEmptyStateDetection();
+    this.initializePageLayout();
+    this.initializeSplashScreen();
+    this.initializeStatusBar();
+    this.statisticsService.checkAndGenerateStatsUid();
+  }
+
+  private initializeLanguage(): void {
+    // Charge les langues disponibles à partir du paramètre 'language' dans le fichier d'environnement
+    this.languages = this.environment.languages;
+    this.translateService.addLangs(this.languages);
+    // Observable permettant de mettre à jour le code language dans l'entête html et d'appliquer la langue choisie
+    currentLanguage$.pipe(
+      distinctUntilChanged(),
+      takeUntil(this.destroy$)
+    ).subscribe(language => {
+      // Mise à jour du langage dans l'application et dans l'attribut lang de l'élément HTML
+      this.translateService.use(language || this.environment.defaultLanguage);
+      this.document.documentElement.lang = language || this.environment.defaultLanguage;
     });
-    this.appResumeListener.then((listener) => {
-      listener.remove();
+  }
+
+  private initializeEmptyStateDetection(): void {
+    const featuresIsEmpty$ : Observable<boolean> = features$.pipe(map(val => val.length === 0));
+    this.isNothingToShow$ = isFeatureStoreInitialized$.pipe(
+      filter(isInitialized => isInitialized),
+      switchMap(() => combineLatest([featuresIsEmpty$, this.networkService.isOnline$])),
+      switchMap(([featuresIsEmpty, isOnline]) => {
+        if (featuresIsEmpty && isOnline) {
+          return this.featuresService.loadAndStoreFeatures().pipe(map(() => false));
+        }
+        return of(featuresIsEmpty || !isOnline);
+      }),
+      distinctUntilChanged(),
+      takeUntil(this.destroy$)
+    );
+    this.isNothingToShow$.subscribe();
+  }
+
+  private initializePageLayout(): void {
+    this.currentPageLayout$ = this.pageLayoutService.currentPageLayout$;
+  }
+
+  private initializeSplashScreen(): void {
+    SplashScreen.show({
+      showDuration: 1500,
+      autoHide: true,
+      fadeInDuration: 500
+    });
+  }
+
+  private initializeStatusBar(): void {
+    if (!Capacitor.isNativePlatform()) {
+      return;
+    }
+    this.platform.ready().then(() => {
+      StatusBar.setStyle({ style: Style.Dark });
     });
   }
 
   public async initializeFirebase(): Promise<void> {
-    if (Capacitor.isNativePlatform()) {
-      return;
+    try {
+      initializeApp(this.environment.firebase);
+    } catch (error) {
+      console.error('Error initializing Firebase:', error);
     }
-    initializeApp(this.environment.firebase);
   }
 
   /**
@@ -242,27 +243,18 @@ export class AppComponent implements OnInit, OnDestroy {
    * with the number of notifications in notification center
    */
   private async handleBadge(): Promise<void> {
-    const isIos = (await Device.getInfo()).platform === 'ios';
-    const notSupported = !(await Badge.isSupported());
-    if (notSupported || !isIos) { // The badge is already well handled on android, no need to do it manually
+    const deviceInfo = await Device.getInfo();
+    if (deviceInfo.platform !== 'ios' || !(await Badge.isSupported())) {
       return;
     }
 
-    // Will be called when the user launches the app, then each time the app enters or exits background
     const fixBadgeCount = async () => {
       const notificationList = await FirebaseMessaging.getDeliveredNotifications();
-      return Badge.set({
-        count: notificationList.notifications.length
-      });
+      return Badge.set({ count: notificationList.notifications.length });
     };
 
-    this.subscriptions.push(this.platform.pause.subscribe(async () => {
-      await fixBadgeCount();
-    }));
-
-    this.subscriptions.push(this.platform.resume.subscribe(async () => {
-      await fixBadgeCount();
-    }));
+    this.platform.pause.pipe(takeUntil(this.destroy$)).subscribe(fixBadgeCount);
+    this.platform.resume.pipe(takeUntil(this.destroy$)).subscribe(fixBadgeCount);
 
     await fixBadgeCount();
   }

--- a/dev/user-frontend-ionic/src/app/layout/layout.page.html
+++ b/dev/user-frontend-ionic/src/app/layout/layout.page.html
@@ -38,18 +38,18 @@
   -->
 
 <ion-tabs>
-    <ion-header *ngIf="currentPageLayout === 'tabs'">
-
+  <ion-header *ngIf="currentPageLayout === 'tabs'">
     <ion-toolbar>
-      <img src="assets/logos/white-logo.svg" class="logo ion-padding-start app-logo-3" alt="logo" aria-label="" />
-      <ion-buttons slot="end" *ngFor="let menuItemHasBadge of [(menuItemHasBadge$ | async) ?? []]">
-        <ion-button *ngFor="let menu of (topMenuItems$ | async) ; let i = index"
-        (click)="menuOpenerService.open(menu)"
-        [attr.data-menu-id]="getMenuId(menu)">
+      <img src="assets/logos/white-logo.svg" class="logo ion-padding-start app-logo-3" alt="logo" aria-label="logo" />
+      <ion-buttons slot="end">
+        <ion-button *ngFor="let menu of (topMenuItemsWithBadges$ | async)"
+                    (click)="menuOpenerService.open(menu)"
+                    (keydown)="menuOpenerService.open(menu)"
+                    [attr.data-menu-id]="getMenuId(menu)">
           <app-custom-icon [icon]="menu.icon"
-          [iconSourceSvgLightTheme]="menu.iconSourceSvgLightTheme"
-          [iconSourceSvgDarkTheme]="menu.iconSourceSvgDarkTheme"></app-custom-icon>
-          <span class="menu-icon-badge" *ngIf="menuItemHasBadge[i] ?? false"></span>
+                           [iconSourceSvgLightTheme]="menu.iconSourceSvgLightTheme"
+                           [iconSourceSvgDarkTheme]="menu.iconSourceSvgDarkTheme"></app-custom-icon>
+          <span class="menu-icon-badge" *ngIf="menu.hasBadge"></span>
         </ion-button>
       </ion-buttons>
     </ion-toolbar>
@@ -60,27 +60,24 @@
         <ion-text class="no-network-label app-text-5">{{"ERROR.NO_NETWORK.TOP_BAR_LABEL" | translate}}</ion-text>
       </ion-col>
     </ion-row>
-
   </ion-header>
-  <ion-tab-bar data-menu-id="main-tab-bar" color="primary" slot="bottom" *ngIf="currentPageLayout === 'tabs'">
 
-    <!--
-      We must set 'tab-selected' class manually because ion-tab-bar has troubles to mark tab as selected
-      when current route contains '/'. It doesn't work with selected attribute either.
-    -->
+  <ion-tab-bar data-menu-id="main-tab-bar" color="primary" slot="bottom" *ngIf="currentPageLayout === 'tabs'">
     <ion-tab-button
       *ngFor="let menu of (tabsMenuItems$ | async);"
       (click)="openExternalOrSsoLinkOnly(menu)"
+      (keydown)="openExternalOrSsoLinkOnly(menu)"
       [routerLink]="menu.routerLink"
       routerLinkActive="tab-selected"
       [attr.data-menu-id]="generateMenuItemIdFromRouterLink(menu)"
     >
       <app-custom-icon [icon]="menu.icon"
-      [iconSourceSvgLightTheme]="menu.iconSourceSvgLightTheme"
-      [iconSourceSvgDarkTheme]="menu.iconSourceSvgDarkTheme"></app-custom-icon>
+                       [iconSourceSvgLightTheme]="menu.iconSourceSvgLightTheme"
+                       [iconSourceSvgDarkTheme]="menu.iconSourceSvgDarkTheme"></app-custom-icon>
       <ion-text class="short-title">
         {{(menu.shortTitle || menu.title) | translate}}
       </ion-text>
     </ion-tab-button>
   </ion-tab-bar>
 </ion-tabs>
+


### PR DESCRIPTION
## Checklist de PR
Veuillez vérifier que votre PR respecte bien les indications suivantes :

- [x] Votre PR pointe vers la branche `develop`
- [x] Votre PR suit les différentes étapes du guide de contribution : https://www.esup-portail.org/wiki/x/KQCeUQ
- [x] Les modifications ont été testées de votre côté, cela implique également des tests sur des périphériques (iOS + Android) si le client a évolué
- [ ] La documentation a été mise à jour et prend en compte les changements (fichiers README, Wiki Esup)

## Type de PR
Quel type de changement concerne cette PR ?

- [x] Bug Fix
- [ ] Nouvelle Feature
- [ ] Mise à jour de la documentation (README, CHANGELOG, CONTRIBUTING)
- [ ] Style (SCSS, Assets)
- [x] Refactoring de code
- [ ] Ajout de tests
- [ ] Build (scripts npm, .sh)
- [ ] CI
- [ ] Chore (nouvelle Release, maj de dépendances)
- [ ] Revert

## Quel est le comportement actuel ?
Au premier chargement de l'application ou à la première connexion de l'utilisateur, certains widgets en page d'accueil s'affichaient sans leur contenu.
Il semblerait que ce soit dû au fait que l'event indiquant aux widgets de récupérer leurs données soit lancé avant même que certains widgets aient fini de s'initialiser.
Bug 4269 (gestion en interne)

## Quel est le nouveau comportement ?
Utilisation du type ReplaySubject<string[]> au lieu de Subject sur les events custom onWidgetDidEnter() qui rejouent la souscription aux données features pour les widgets qui auraient tardé à s'initialiser et n'auraient pas capté l'event.

## Cette PR implique un Breaking Change ?
- [ ] Oui
- [x] Non

## Information complémentaire
Avant de merger cette PR, il faudrait tester et valider le fonctionnement sur des périphériques réels.
De mon côté, cela a été testé de long en large sur IPhone (12) et Android (Samsung A53) sans détecter de problèmes particuliers, mais le comportement de souscription aux observables des Widgets ayant été modifié, il n'est pas impossible que cela puisse générer des effets de bords non prévus ou des problèmes de performance. Donc plus il y a de tests différents plus on réduit la probabilité d'apparition d'éventuels problèmes.
