### PR TITLE
ci: correction workflow libs, permissions push manquantes si fork

### DIFF
--- a/.github/workflows/update libs.yml
+++ b/.github/workflows/update libs.yml
@@ -1,4 +1,4 @@
-name: Update library list
+name: Check library list
 permissions:
   contents: write
   pull-requests: write
@@ -8,7 +8,7 @@ on:
     types: [ opened, synchronize ]
 
 jobs:
-  update-library-list:
+  check-library-list:
     runs-on: ubuntu-latest
 
     steps:
@@ -42,21 +42,36 @@ jobs:
           chmod +x generateLibraryList.bash
           ./generateLibraryList.bash
 
-      - name: Add changes to Git
+      - name: Check for changes
+        id: diff
         if: steps.changes.outputs.packageJson == 'true'
         run: |
           git config core.fileMode false
+          git diff -w --ignore-blank-lines
+          echo "CHANGES=$(( $(git diff -w --ignore-blank-lines | wc -l) > 0 ? 1 : 0 ))" >> $GITHUB_OUTPUT
+
+      - name: Add changes to Git
+        if: steps.changes.outputs.packageJson == 'true' && steps.diff.outputs.CHANGES == 1 && github.event.pull_request.head.repo.full_name == github.repository
+        run: |
           git add -A
 
       - name: Commit changes
-        if: steps.changes.outputs.packageJson == 'true'
+        if: steps.changes.outputs.packageJson == 'true' && steps.diff.outputs.CHANGES == 1 && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config --local user.name "GitHub Action"
           git config --local user.email "action@github.com"
           git commit -m "docs: update library list" || echo "No changes to commit"
 
       - name: Push changes
-        if: steps.changes.outputs.packageJson == 'true'
+        if: steps.changes.outputs.packageJson == 'true' && steps.diff.outputs.CHANGES == 1 && github.event.pull_request.head.repo.full_name == github.repository
         run: git push origin HEAD:${{ github.head_ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fork  detected
+        if: steps.changes.outputs.packageJson == 'true' && steps.diff.outputs.CHANGES == 1 && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "La liste des dépendances doit être mise à jour."
+          echo "A cause d'une limitation de GitHub Actions, il est impossible de mettre à jour la liste des dépendances depuis un fork."
+          echo "Merci d'exécuter le script 'generateLibraryList.bash' de votre côté."
+          exit 1


### PR DESCRIPTION
## Checklist de PR
Veuillez vérifier que votre PR respecte bien les indications suivantes :

- [x] Votre PR pointe vers la branche `develop`
- [x] Votre PR suit les différentes étapes du guide de contribution : https://www.esup-portail.org/wiki/x/KQCeUQ
- [x] Les modifications ont été testées de votre côté, cela implique également des tests sur des périphériques (iOS + Android) si le client a évolué
- [x] La documentation a été mise à jour et prend en compte les changements (fichiers README, Wiki Esup)

## Type de PR
Quel type de changement concerne cette PR ?

- [ ] Bug Fix
- [ ] Nouvelle Feature
- [ ] Mise à jour de la documentation (README, CHANGELOG, CONTRIBUTING)
- [ ] Style (SCSS, Assets)
- [ ] Refactoring de code
- [ ] Ajout de tests
- [ ] Build (scripts npm, .sh)
- [x] CI
- [ ] Chore (nouvelle Release, maj de dépendances)
- [ ] Revert

## Quel est le comportement actuel ?
Permissions manquantes pour commit et push si la PR vient d'un fork (problème différent du checkout corrigé dans une PR précédente).
Le workflow échoue systématiquement.

## Quel est le nouveau comportement ?
Impossible d'accorder ces permissions ou d'ajouter un message directement sur la PR.
Désormais, on n'essaye plus de commit les changements pour les forks, le workflow échoue en cas de différence et indique qu'il faut lancer le script à la main.

## Cette PR implique un Breaking Change ?
- [ ] Oui
- [x] Non

## Information complémentaire
RAS
