### PR TITLE
refactor(@multi-fontend/widget-next-events) amélioration adaptabilité style

### DIFF
--- a/dev/user-frontend-ionic/projects/schedule/src/lib/widgets/next-events/next-events.component.html
+++ b/dev/user-frontend-ionic/projects/schedule/src/lib/widgets/next-events/next-events.component.html
@@ -48,54 +48,60 @@
         {{ "SCHEDULE.WIDGET.NEXT_EVENTS.NO_EVENTS" | translate }}
       </ion-note>
     </ion-row>
+    <div *ngFor="let date of getUniqueDates()" class="day-events">
+      <ion-col *ngFor="let event of getEventsForDate(date); let last = last" class="ion-no-padding">
+        <ion-row *ngIf="displayDateForIds.includes(event.id)" class="event-day">
+          <ion-text [ngClass]="fontColor()" class="app-title-6 light">
+            {{ event.startDateTime | completeLocalDate }}
+          </ion-text>
+        </ion-row>
 
-    <ion-col *ngFor="let event of (nextEvents$ | async) let last = last" class="ion-no-padding">
-      <ion-row *ngIf="displayDateForIds.includes(event.id)" class="event-day">
-        <ion-text [ngClass]="fontColor()" class="app-title-6 light">
-          {{ event.startDateTime | completeLocalDate }}
-        </ion-text>
-      </ion-row>
+        <ion-card [ngClass]="{'last-card': last}">
+          <div class="circle-top-left"></div>
+          <div class="dashed-line"></div>
 
-      <ion-card [ngClass]="{'last-card': last}">
-        <div class="circle-top-left"></div>
-        <div class="dashed-line"></div>
+          <ion-card-header>
+            <ion-card-title [ngClass]="fontColor()"
+                            class="app-title-5 light">
+              {{ event.startDateTime | localHour }} - {{ event.endDateTime | localHour }}
+            </ion-card-title>
+          </ion-card-header>
 
-        <ion-card-header>
-          <ion-card-title [ngClass]="fontColor()"
-            class="app-title-5 light">
-            {{event.startDateTime | localHour}} - {{event.endDateTime | localHour}}
-          </ion-card-title>
-        </ion-card-header>
-
-        <ion-card-content>
-          <ion-row>
-            <ion-col>
-              <ion-text [ngClass]="fontColor()"
-                class="app-title-5">{{event.course.label}}</ion-text>
-              <ion-row>
-                <ion-row class="ion-align-items-center card-labels" *ngFor="let room of event.rooms">
-                  <ion-icon [ngClass]="[fontColor(), 'card-labels-icons']" name="business-outline" aria-label=""></ion-icon>
-                  <ion-text [ngClass]="fontColor()"
-                    class="app-title-6 light">{{room.label}} - {{room.building}}</ion-text>
+          <ion-card-content>
+            <ion-row>
+              <ion-col>
+                <ion-text [ngClass]="fontColor()"
+                          class="app-title-5">{{ event.course.label }}
+                </ion-text>
+                <ion-row>
+                  <ion-row class="ion-align-items-center card-labels" *ngFor="let room of event.rooms">
+                    <ion-icon [ngClass]="[fontColor(), 'card-labels-icons']" name="business-outline"
+                              aria-label=""></ion-icon>
+                    <ion-text [ngClass]="fontColor()"
+                              class="app-title-6 light">{{ room.label }} - {{ room.building }}
+                    </ion-text>
+                  </ion-row>
+                  <ion-row class="ion-align-items-center card-labels" *ngFor="let teacher of event.teachers">
+                    <ion-icon [ngClass]="fontColor()"
+                              class="card-labels-icons" name="man-outline" aria-label=""></ion-icon>
+                    <ion-text [ngClass]="fontColor()"
+                              class="app-title-6 light">{{ teacher.displayname }}
+                    </ion-text>
+                  </ion-row>
+                  <ion-row class="ion-align-items-center card-labels" *ngIf="event.course.url">
+                    <ion-icon [ngClass]="fontColor()"
+                              class="card-labels-icons" name="link-outline" aria-label=""></ion-icon>
+                    <ion-text [ngClass]="fontColor()"
+                              class="app-title-6 light">{{ event.course.url | truncate:35 }}
+                    </ion-text>
+                  </ion-row>
                 </ion-row>
-                <ion-row class="ion-align-items-center card-labels" *ngFor="let teacher of event.teachers">
-                  <ion-icon [ngClass]="fontColor()"
-                    class="card-labels-icons" name="man-outline" aria-label=""></ion-icon>
-                  <ion-text [ngClass]="fontColor()"
-                    class="app-title-6 light">{{teacher.displayname}}</ion-text>
-                </ion-row>
-                <ion-row class="ion-align-items-center card-labels" *ngIf="event.course.url">
-                  <ion-icon [ngClass]="fontColor()"
-                    class="card-labels-icons" name="link-outline" aria-label=""></ion-icon>
-                  <ion-text [ngClass]="fontColor()"
-                    class="app-title-6 light">{{ event.course.url | truncate:35 }}</ion-text>
-                </ion-row>
-              </ion-row>
-            </ion-col>
-          </ion-row>
-        </ion-card-content>
+              </ion-col>
+            </ion-row>
+          </ion-card-content>
 
-      </ion-card>
-    </ion-col>
+        </ion-card>
+      </ion-col>
+    </div>
   </ion-grid>
 </ng-container>

--- a/dev/user-frontend-ionic/projects/schedule/src/lib/widgets/next-events/next-events.component.ts
+++ b/dev/user-frontend-ionic/projects/schedule/src/lib/widgets/next-events/next-events.component.ts
@@ -37,13 +37,13 @@
  * termes.
  */
 
-import { AfterViewInit, ChangeDetectorRef, Component, Input, OnDestroy } from '@angular/core';
-import { CompleteLocalDatePipe, ThemeService } from '@multi/shared';
-import { Observable, Subscription } from 'rxjs';
-import { finalize, map, take } from 'rxjs/operators';
-import { Event } from '../../schedule.repository';
-import { ScheduleService } from '../../schedule.service';
-import { NextEventsService } from './next-events.service';
+import {AfterViewInit, ChangeDetectorRef, Component, Input, OnDestroy} from '@angular/core';
+import {CompleteLocalDatePipe, ThemeService} from '@multi/shared';
+import {Observable, Subscription} from 'rxjs';
+import {finalize, map, take} from 'rxjs/operators';
+import {Event} from '../../schedule.repository';
+import {ScheduleService} from '../../schedule.service';
+import {NextEventsService} from './next-events.service';
 
 @Component({
   selector: 'app-schedule-widget-next-events',
@@ -75,7 +75,7 @@ export class NextEventsComponent implements OnDestroy, AfterViewInit {
       const idsToDisplay = {};
       events.forEach(event => {
         const eventDay = this.completeLocalDatePipe.transform(event.startDateTime);
-        if(!idsToDisplay[eventDay]) {
+        if (!idsToDisplay[eventDay]) {
           idsToDisplay[eventDay] = event.id;
         }
       });
@@ -111,5 +111,28 @@ export class NextEventsComponent implements OnDestroy, AfterViewInit {
   ngOnDestroy() {
     this.nextEventsSubscription.unsubscribe();
   }
-}
 
+  getUniqueDates(): Set<string> {
+    const uniqueDates: Set<string> = new Set();
+    this.nextEvents$.subscribe(events => {
+      events.forEach(event => {
+        const eventDay = this.completeLocalDatePipe.transform(event.startDateTime);
+        uniqueDates.add(eventDay);
+      });
+    });
+    return uniqueDates;
+  }
+
+  getEventsForDate(date: string): Event[] {
+    const eventsForDate: Event[] = [];
+    this.nextEvents$.subscribe(events => {
+      events.forEach(event => {
+        const eventDay = this.completeLocalDatePipe.transform(event.startDateTime);
+        if (eventDay === date) {
+          eventsForDate.push(event);
+        }
+      });
+    });
+    return eventsForDate;
+  }
+}


### PR DESCRIPTION
refactor(@multi-fontend/widget-next-events) amélioration adaptabilité style

Ajout d'une balise div autour des éléments ion-col afin de les regrouper par jour et de pouvoir appliquer un traitement de style sur les événements d'un même jour.

## Checklist de PR
Veuillez vérifier que votre PR respecte bien les indications suivantes :

- [X] Votre PR pointe vers la branche `develop`
- [X] Votre PR suit les différentes étapes du guide de contribution : https://www.esup-portail.org/wiki/x/KQCeUQ
- [X] Les modifications ont été testées de votre côté, cela implique également des tests sur des périphériques (iOS + Android) si le client a évolué
- [X] La documentation a été mise à jour et prend en compte les changements (fichiers README, Wiki Esup)

## Type de PR
Quel type de changement concerne cette PR ?

- [ ] Bug Fix
- [ ] Nouvelle Feature
- [ ] Mise à jour de la documentation (README, CHANGELOG, CONTRIBUTING)
- [ ] Style (SCSS, Assets)
- [X] Refactoring de code
- [ ] Ajout de tests
- [ ] Build (scripts npm, .sh)
- [ ] CI
- [ ] Chore (nouvelle Release, maj de dépendances)
- [ ] Revert

## Quel est le comportement actuel ?
Actuellement, chacun des événements du widget est indépendant des autres. Certains contiennent la date du jour et d'autres non. Il n'est pas possible de traiter les événements d'un même jour avec un style commun.

## Quel est le nouveau comportement ?
L'ajout de la balise div autour des ion-col pour chacun des jours, permet d'appliquer un style au jour puis ensuite aux événements.
Cela dans le cas de l'URCA va nous permettre d'afficher l'ensemble des événements d'un même jour dans un cadre commun.

## Cette PR implique un Breaking Change ?
- [ ] Oui
- [X] Non