### PR TITLE
fix(@multi-frontend/schedule): liste vide voir plus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Client
 #### Bug fixes
 * **(restaurants)** : correction des dates tronquées à cause d'un scroll vertical inutile
+* **(schedule)** : correction du bouton 'Voir Plus' de la vue liste de l'emploi du temps qui n'affichait pas lorsque l'étudiant n'a pas de cours pendant plus de 15 jours
 
 ## 1.2.0 (2024-12-11)
 

--- a/dev/user-frontend-ionic/projects/schedule/src/lib/schedule-list/schedule-list.page.html
+++ b/dev/user-frontend-ionic/projects/schedule/src/lib/schedule-list/schedule-list.page.html
@@ -39,36 +39,28 @@
 
 <ion-content *ngIf="(storeManager.schedule$ | async) as schedule" #scrollContent>
 
-  <ng-container *ngIf="(areEventsFromActivePlannings$ | async) === true">
+  <ion-item-group *ngFor="let eventsByDay of (eventsByDays$ | async);">
 
-    <ion-item-group *ngFor="let eventsByDay of (eventsByDays$ | async);">
+    <ion-item-divider sticky class="app-text-2 ion-text-center complete-date" [id]="eventsByDay.day">
+      <ion-col>{{eventsByDay.day | completeLocalDate}}</ion-col>
+    </ion-item-divider>
 
-      <ion-item-divider sticky class="app-text-2 ion-text-center complete-date" [id]="eventsByDay.day">
-        <ion-col>{{eventsByDay.day | completeLocalDate}}</ion-col>
-      </ion-item-divider>
+    <ion-col class="app-text-4 ion-text-center safe-area-padding-lr" *ngIf="!eventsByDay.events.length">
+      <p>{{ "SCHEDULE.NO_EVENTS_THIS_DAY" | translate }}</p>
+    </ion-col>
 
-      <ion-col class="app-text-4 ion-text-center safe-area-padding-lr" *ngIf="!eventsByDay.events.length">
-        <p>{{ "SCHEDULE.NO_EVENTS_THIS_DAY" | translate }}</p>
-      </ion-col>
+    <app-event-detail *ngFor="let event of eventsByDay.events" [event]="event"
+      (hideEventEvt)="keepScrollPosition()"></app-event-detail>
 
-      <app-event-detail *ngFor="let event of eventsByDay.events" [event]="event"
-        (hideEventEvt)="keepScrollPosition()"></app-event-detail>
+  </ion-item-group>
 
-    </ion-item-group>
+  <ion-row class="ion-justify-content-center ion-margin-bottom">
+    <ion-button class="app-text-4 see-more" fill="outline" (click)="loadMoreEvents()">
+      <ion-icon name="add-outline" aria-label=""></ion-icon>
+      {{ "SCHEDULE.LIST.SEE_MORE" | translate }}
+    </ion-button>
+  </ion-row>
 
-    <ion-row class="ion-justify-content-center ion-margin-bottom">
-      <ion-button class="app-text-4 see-more" fill="outline" (click)="loadMoreEvents()">
-        <ion-icon name="add-outline" aria-label=""></ion-icon>
-        {{ "SCHEDULE.LIST.SEE_MORE" | translate }}
-      </ion-button>
-    </ion-row>
-
-  </ng-container>
-
-</ion-content>
-
-<ion-content class="ion-padding" *ngIf="(areEventsFromActivePlannings$ | async) === false">
-  <ion-note class="app-text-4 safe-area-padding-lr"> {{ "SCHEDULE.NO_EVENTS" | translate }} </ion-note>
 </ion-content>
 
 <ion-content class="ion-padding" *ngIf="(storeManager.schedule$ | async) === null">


### PR DESCRIPTION
## Checklist de PR
Veuillez vérifier que votre PR respecte bien les indications suivantes :

- [x] Votre PR pointe vers la branche `develop`
- [x] Votre PR suit les différentes étapes du guide de contribution : https://www.esup-portail.org/wiki/x/KQCeUQ
- [x] Les modifications ont été testées de votre côté, cela implique également des tests sur des périphériques (iOS + Android) si le client a évolué
- [ ] La documentation a été mise à jour et prend en compte les changements (fichiers README, Wiki Esup)

## Type de PR
Quel type de changement concerne cette PR ?

- [x] Bug Fix
- [ ] Nouvelle Feature
- [ ] Mise à jour de la documentation (README, CHANGELOG, CONTRIBUTING)
- [ ] Style (SCSS, Assets)
- [ ] Refactoring de code
- [ ] Ajout de tests
- [ ] Build (scripts npm, .sh)
- [ ] CI
- [ ] Chore (nouvelle Release, maj de dépendances)
- [ ] Revert

## Quel est le comportement actuel ?
Dans la vue liste de l'emploi du temps, on peut avoir le message « Pas de cours dans vos plannings » si on n'a pas de cours dans les prochaines semaines.

Lien vers l'issue : https://gesproj.univ-lorraine.fr/plugins/tracker/?aid=7416

## Quel est le nouveau comportement ?
Il y avait un test sur la présence de plannings dans ce qui venait du *schedule provider*. Or, à l'UL, si on n'a pas de cours, ce-dernier n'ajoute pas le planning à la liste.

Ce test a été retiré de l'affichage, on a toujours la liste et le bouton « Voir plus » visibles. L'observable est toujours présent, si jamais on veut revenir dessus.

## Cette PR implique un Breaking Change ?
- [ ] Oui
- [x] Non

## Information complémentaire
Indiquez des informations complémentaires qui pourraient faciliter la revue de code et le check de cette PR
