### PR TITLE
fix(@multi-frontend/app-update) Accès apiEndpoint suite passage multi-tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## next version...
 
 ### Client
+
+#### Bug fixes
+* **(app-update)**: Le client n'était plus capable de récupérer la version min requise suite au passage au multi-tenants
+
 #### Autres
 * Mises à jour des dépendances suite aux alertes CVE
 

--- a/dev/user-frontend-ionic/projects/app-update/src/lib/app-update.module.ts
+++ b/dev/user-frontend-ionic/projects/app-update/src/lib/app-update.module.ts
@@ -41,18 +41,15 @@ import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { ProjectModuleService } from '@multi/shared';
 import { CommonModule } from '@angular/common';
 import { IonicModule } from '@ionic/angular';
-import { AppUpdateService } from './app-update.service';
 import { TranslateModule } from '@ngx-translate/core';
 
 
-const initModule = (projectModuleService: ProjectModuleService, appUpdateService: AppUpdateService) =>
+const initModule = (projectModuleService: ProjectModuleService) =>
   () => {
     projectModuleService.initProjectModule({
       name: 'app-update',
       translation: true,
     });
-
-    appUpdateService.initialize();
   }
 
 @NgModule({
@@ -65,7 +62,7 @@ const initModule = (projectModuleService: ProjectModuleService, appUpdateService
     {
       provide: APP_INITIALIZER,
       useFactory: initModule,
-      deps:[ProjectModuleService, AppUpdateService],
+      deps:[ProjectModuleService],
       multi: true
     }
   ],


### PR DESCRIPTION
## Checklist de PR
Veuillez vérifier que votre PR respecte bien les indications suivantes :

- [x] Votre PR pointe vers la branche `develop`
- [x] Votre PR suit les différentes étapes du guide de contribution : https://www.esup-portail.org/wiki/x/KQCeUQ
- [x] Les modifications ont été testées de votre côté, cela implique également des tests sur des périphériques (iOS + Android) si le client a évolué
- [ ] La documentation a été mise à jour et prend en compte les changements (fichiers README, Wiki Esup)

## Type de PR
Quel type de changement concerne cette PR ?

- [x] Bug Fix
- [ ] Nouvelle Feature
- [ ] Mise à jour de la documentation (README, CHANGELOG, CONTRIBUTING)
- [ ] Style (SCSS, Assets)
- [ ] Refactoring de code
- [ ] Ajout de tests
- [ ] Build (scripts npm, .sh)
- [ ] CI
- [ ] Chore (nouvelle Release, maj de dépendances)
- [ ] Revert

## Quel est le comportement actuel ?

Suite au passage au multi-tenants, le module app-update n'était plus capable de récupérer l'url du backend pour obtenir la version client minimum requise.

## Quel est le nouveau comportement ?
L'url du backend est récupérée via la fonction mise à dispo multiTenantService.getApiEndpoint().
Cependant, l'ordre de chargement des modules a du être revu pour que app-update ne soit initialisé qu'une fois multi-tenant 'ready'.

## Cette PR implique un Breaking Change ?
- [ ] Oui
- [x] Non

## Information complémentaire
Le fonctionnement a été testé avec plusieurs tenants. Seulement la proposition de mise à jour n'est faite qu'une fois le tenant sélectionné (logique vu que nous n'avons pas d'url de backend définie avant cela)
